### PR TITLE
fix: Resolve SSR issue with TerminalApp

### DIFF
--- a/components/app-launcher.tsx
+++ b/components/app-launcher.tsx
@@ -22,8 +22,15 @@ import {
   ShoppingBag,
 } from "lucide-react"
 import { Input } from "@/components/ui/input"
-import TerminalApp from "./apps/terminal-app" // Import the new TerminalApp
+// import TerminalApp from "./apps/terminal-app" // Removed static import
 import { Button } from "@/components/ui/button"
+import dynamic from 'next/dynamic' // Added dynamic import
+
+// Dynamically import TerminalApp
+const TerminalApp = dynamic(() => import('./apps/terminal-app'), {
+  ssr: false,
+  loading: () => <p>Loading Terminal...</p>
+});
 
 interface App {
   id: string


### PR DESCRIPTION
I've dynamically imported the TerminalApp component in the AppLauncher to prevent xterm.js from being loaded on the server-side. This fixes the "ReferenceError: self is not defined" that occurred during server-side rendering.

The previous commit "feat: Implement Terminal app with WebContainer (Ubuntu)" introduced the TerminalApp, and this commit ensures it's compatible with Next.js SSR by client-side loading.