### PR TITLE
fix: Add COOP/COEP headers for WebContainer compatibility

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,24 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  async headers() {
+    return [
+      {
+        // Apply these headers to all routes in your application.
+        source: '/:path*',
+        headers: [
+          {
+            key: 'Cross-Origin-Opener-Policy',
+            value: 'same-origin',
+          },
+          {
+            key: 'Cross-Origin-Embedder-Policy',
+            value: 'require-corp',
+          },
+        ],
+      },
+    ];
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
WebContainers require a cross-origin isolated environment to use SharedArrayBuffer. This commit updates `next.config.mjs` to include the necessary HTTP headers:
- Cross-Origin-Opener-Policy: same-origin
- Cross-Origin-Embedder-Policy: require-corp

These headers enable the cross-origin isolation needed by the TerminalApp's WebContainer, resolving the `DataCloneError` that occurred during its boot process.