### PR TITLE
Fix: Correctly write to WebContainer shell process input

### DIFF
--- a/components/apps/terminal-app.test.tsx
+++ b/components/apps/terminal-app.test.tsx
@@ -5,62 +5,90 @@ import TerminalApp from './terminal-app';
 // Mock WebContainer and xterm.js for basic tests if full e2e setup is not available.
 // This is a simplified example. Real tests would need more sophisticated mocking or an e2e environment.
 
+// Define mocks outside of jest.mock calls to allow for easy access in tests
+const mockWriter = {
+  write: jest.fn().mockResolvedValue(undefined),
+  releaseLock: jest.fn().mockResolvedValue(undefined),
+  close: jest.fn().mockResolvedValue(undefined),
+};
+
+const mockShellProcess = {
+  input: {
+    getWriter: jest.fn().mockReturnValue(mockWriter),
+  },
+  output: {
+    pipeTo: jest.fn().mockImplementation(async (stream) => {
+      // Simulate some output for basic checks
+      // await stream.write('jsh > '); // Commented out to simplify tests
+      return Promise.resolve();
+    }),
+  },
+  exit: Promise.resolve(0),
+};
+
+const mockWebContainerInstance = {
+  mount: jest.fn().mockResolvedValue(undefined),
+  spawn: jest.fn().mockResolvedValue(mockShellProcess),
+  on: jest.fn(),
+  teardown: jest.fn(),
+};
+
 jest.mock('@webcontainer/api', () => ({
   WebContainer: {
-    boot: jest.fn().mockResolvedValue({
-      mount: jest.fn().mockResolvedValue(undefined),
-      spawn: jest.fn().mockResolvedValue({
-        input: {
-          write: jest.fn(),
-        },
-        output: {
-          pipeTo: jest.fn().mockImplementation(async (stream) => {
-            // Simulate some output for basic checks
-            await stream.write('jsh > ');
-            return Promise.resolve();
-          }),
-        },
-        exit: Promise.resolve(0),
-      }),
-      on: jest.fn(), // Mock 'on' method
-      teardown: jest.fn(), // Mock 'teardown' method
-    }),
+    boot: jest.fn().mockResolvedValue(mockWebContainerInstance),
   },
 }));
 
-jest.mock('xterm', () => {
-  const mockTerminal = {
-    loadAddon: jest.fn(),
-    open: jest.fn(),
-    write: jest.fn(),
-    onData: jest.fn().mockImplementation((callback) => {
-      // To simulate user input for a command
-      // setTimeout(() => callback('echo hello'), 100);
-      return { dispose: jest.fn() }; // Return a disposable
-    }),
-    dispose: jest.fn(),
-    // Mock addons if FitAddon is accessed directly
-    addons: {
-        fit: {
-            fit: jest.fn()
-        }
-    }
-  };
-  return {
-    Terminal: jest.fn().mockImplementation(() => mockTerminal),
-  };
-});
+// Capture the onData callback
+let onDataCallback: ((data: string) => void) | null = null;
+
+const mockTerminalInstance = {
+  loadAddon: jest.fn(),
+  open: jest.fn(),
+  write: jest.fn(),
+  onData: jest.fn().mockImplementation((callback) => {
+    onDataCallback = callback; // Capture the callback
+    return { dispose: jest.fn() };
+  }),
+  dispose: jest.fn(),
+  addons: {
+    fit: {
+      fit: jest.fn(),
+    },
+  },
+  clear: jest.fn(), // Added for completeness
+  focus: jest.fn(), // Added for completeness
+};
+
+jest.mock('xterm', () => ({
+  Terminal: jest.fn().mockImplementation(() => mockTerminalInstance),
+}));
 
 jest.mock('xterm-addon-fit', () => ({
   FitAddon: jest.fn().mockImplementation(() => ({
     activate: jest.fn(),
     dispose: jest.fn(),
-    fit: jest.fn(), // Mock fit method
+    fit: jest.fn(),
   })),
 }));
 
 
 describe('TerminalApp', () => {
+  // Clear mocks before each test
+  beforeEach(() => {
+    jest.clearAllMocks();
+    onDataCallback = null; // Reset captured callback
+
+    // Re-assign mock implementations if they were modified directly in a test
+    mockWebContainerInstance.spawn.mockResolvedValue(mockShellProcess);
+    mockShellProcess.input.getWriter.mockReturnValue(mockWriter);
+    mockWriter.write.mockResolvedValue(undefined);
+    mockWriter.releaseLock.mockResolvedValue(undefined);
+    (require('@webcontainer/api').WebContainer.boot as jest.Mock).mockResolvedValue(mockWebContainerInstance);
+    (require('xterm').Terminal as jest.Mock).mockImplementation(() => mockTerminalInstance);
+
+  });
+
   it('renders the terminal container', () => {
     render(<TerminalApp />);
     // Check if the main div for the terminal is rendered.
@@ -77,7 +105,8 @@ describe('TerminalApp', () => {
 
     // Wait for async operations in useEffect to complete
     await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 0)); // Allow microtasks to flush
+      // Flushes microtasks
+      await new Promise(resolve => setImmediate(resolve));
     });
 
     expect(Terminal).toHaveBeenCalled();
@@ -101,23 +130,97 @@ describe('TerminalApp', () => {
     expect(terminalInstance.write).toHaveBeenCalledWith('WebContainer booted successfully!\r\n');
     // The following depends on the successful promise resolution of spawn()
     // and the mock implementation of pipeTo
-    // expect(terminalInstance.write).toHaveBeenCalledWith('Shell process started.\r\n');
-    // expect(terminalInstance.write).toHaveBeenCalledWith('jsh > ');
-
+    // expect(mockTerminalInstance.write).toHaveBeenCalledWith('Shell process started.\r\n');
+    // expect(mockTerminalInstance.write).toHaveBeenCalledWith('jsh > ');
   });
 
+  it('simulates user typing and writes to shell process input', async () => {
+    const { WebContainer } = require('@webcontainer/api');
+    const { Terminal } = require('xterm');
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {}); // Suppress console.error
 
-  // Further tests would require a more complex setup for WebContainer interaction:
-  // - Test sending a command like 'echo hello'
-  //   - Mock term.onData to simulate user typing 'echo hello'
-  //   - Verify that shellProcess.input.write is called with 'echo hello'
-  //   - Mock shellProcess.output to send back 'hello\r\n'
-  //   - Verify that term.write is called with 'hello\r\n'
+    render(<TerminalApp />);
 
-  // - Test resizing the terminal
-  //   - Simulate window resize event
-  //   - Verify fitAddon.fit() is called
+    // Wait for WebContainer to boot and shell to spawn
+    await act(async () => {
+      await new Promise(resolve => setImmediate(resolve));
+    });
 
-  // - Test component unmount
-  //   - Verify terminal.dispose() and webContainerInstance.teardown() are called (if implemented)
+    // Ensure WebContainer.boot was called
+    expect(WebContainer.boot).toHaveBeenCalled();
+
+    // Ensure the mockWebContainerInstance.spawn was called
+    const bootResult = await (WebContainer.boot as jest.Mock).mock.results[0].value;
+    expect(bootResult.spawn).toHaveBeenCalledWith('jsh');
+
+    // Ensure onData callback was captured
+    expect(onDataCallback).not.toBeNull();
+
+    const testInput = 'hello world';
+    // Simulate user typing
+    if (onDataCallback) {
+      await act(async () => {
+        onDataCallback(testInput);
+        // Allow promises from onData (like writer.write) to resolve
+        await new Promise(resolve => setImmediate(resolve));
+      });
+    }
+
+    // Verify that the writer's write method was called with the test input
+    expect(mockWriter.write).toHaveBeenCalledTimes(1);
+    expect(mockWriter.write).toHaveBeenCalledWith(testInput);
+
+    // Check that no errors were logged by the component's write error handling
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('releases writer lock on shell process exit', async () => {
+    // Special mock for this test to control shell exit
+    const controlledMockShellProcess = {
+      ...mockShellProcess,
+      exit: Promise.resolve(0), // This will be resolved by the component
+    };
+    (mockWebContainerInstance.spawn as jest.Mock).mockResolvedValue(controlledMockShellProcess);
+
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await new Promise(resolve => setImmediate(resolve)); // Boot and spawn
+    });
+
+    // Trigger unmount or shell exit logic
+    // In the component, shellProcess.exit.then(...) handles this.
+    // Since `exit` is a promise that resolves, the .then() should execute.
+    // We need to wait for that promise chain.
+    await act(async () => {
+        await controlledMockShellProcess.exit; // Ensure the exit promise chain completes
+        await new Promise(resolve => setImmediate(resolve)); // Flush microtasks
+    });
+
+    expect(mockWriter.releaseLock).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases writer lock on component unmount', async () => {
+    const { unmount } = render(<TerminalApp />);
+
+    await act(async () => {
+      await new Promise(resolve => setImmediate(resolve)); // Boot and spawn
+    });
+
+    act(() => {
+      unmount();
+    });
+
+    // Need to ensure the cleanup function in useEffect is called.
+    // The unmount itself should trigger this.
+    // Let's wait for any promises in cleanup.
+    await act(async () => {
+        await new Promise(resolve => setImmediate(resolve));
+    });
+
+    expect(mockWriter.releaseLock).toHaveBeenCalledTimes(1);
+  });
+
 });


### PR DESCRIPTION
The previous implementation directly called `shellProcess.input.write()`, which caused a TypeError because `shellProcess.input` is a WritableStream and requires a writer to be obtained first.

This commit fixes the issue by:
1. Obtaining a `WritableStreamDefaultWriter` from `shellProcess.input.getWriter()`.
2. Using this writer to send data from the xterm.js terminal to the WebContainer shell process.
3. Storing the writer in a `useRef` to reuse it for subsequent data events.
4. Ensuring the writer's lock is released when the shell process exits or when the component unmounts to prevent resource leaks.
5. Added error handling for the write operation to log any potential errors to the console.

Additionally, this commit enhances the `terminal-app.test.tsx` by:
1. Updating mocks for `WebContainer` and `xterm` to accurately simulate the writer mechanism and capture the `onData` callback.
2. Adding a new test case to simulate user typing and verify that data is correctly written to the shell process input via the writer.
3. Adding test cases to ensure the writer's lock is released on shell process exit and component unmount.