### PR TITLE
feat: Add tools and scripts for Ubuntu snapshot generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "build:ubuntu-snapshot": "node scripts/generate-ubuntu-snapshot.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
@@ -66,6 +67,7 @@
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@webcontainer/snapshot": "^0.1.0",
     "postcss": "^8",
     "tailwindcss": "^3.4.17",
     "typescript": "^5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.1.6(@types/react@19.1.6)
+      '@webcontainer/snapshot':
+        specifier: ^0.1.0
+        version: 0.1.0
       postcss:
         specifier: ^8
         version: 8.5.4
@@ -343,6 +346,10 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@msgpack/msgpack@3.1.2':
+    resolution: {integrity: sha512-JEW4DEtBzfe8HvUYecLU9e6+XJnKDlUAIve8FvPzF3Kzs6Xo/KuZkZJsDH0wJXl/qEZbeeE7edxDNY3kMs39hQ==}
+    engines: {node: '>= 18'}
 
   '@next/env@15.2.4':
     resolution: {integrity: sha512-+SFtMgoiYP3WoSswuNmxJOCwi06TdWE733D+WPjpXIe4LXGULwEaofiiAy6kbS0+XjM5xF5n3lKuBwN2SnqD9g==}
@@ -1113,6 +1120,10 @@ packages:
 
   '@webcontainer/api@1.6.1':
     resolution: {integrity: sha512-2RS2KiIw32BY1Icf6M1DvqSmcon9XICZCDgS29QJb2NmF12ZY2V5Ia+949hMKB3Wno+P/Y8W+sPP59PZeXSELg==}
+
+  '@webcontainer/snapshot@0.1.0':
+    resolution: {integrity: sha512-PTIGQ3osUpTbK/dqB8RYbcZGv8IK+DJACx709z5sFbeIlngB3hUFpTEYFYs1SbUvr/AEQqvd0/bhc4ectrPRRw==}
+    engines: {node: '>=16'}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -2032,6 +2043,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  '@msgpack/msgpack@3.1.2': {}
+
   '@next/env@15.2.4': {}
 
   '@next/swc-darwin-arm64@15.2.4':
@@ -2808,6 +2821,10 @@ snapshots:
       csstype: 3.1.3
 
   '@webcontainer/api@1.6.1': {}
+
+  '@webcontainer/snapshot@0.1.0':
+    dependencies:
+      '@msgpack/msgpack': 3.1.2
 
   ansi-regex@5.0.1: {}
 

--- a/scripts/generate-ubuntu-snapshot.js
+++ b/scripts/generate-ubuntu-snapshot.js
@@ -1,0 +1,49 @@
+// scripts/generate-ubuntu-snapshot.js
+const fs = require('fs').promises;
+const path = require('path');
+const { snapshot } = require('@webcontainer/snapshot');
+
+const SOURCE_DIR_NAME = 'assets/ubuntu-fs';
+const OUTPUT_FILE_NAME = 'public/ubuntu.bin';
+
+const currentDir = __dirname; // Gets the directory where the script is located (scripts/)
+const projectRoot = path.resolve(currentDir, '..'); // Navigate up to the project root
+
+const sourcePath = path.join(projectRoot, SOURCE_DIR_NAME);
+const outputPath = path.join(projectRoot, OUTPUT_FILE_NAME);
+
+async function generateSnapshot() {
+  console.log(`Attempting to generate snapshot from: ${sourcePath}`);
+  console.log(`Output will be written to: ${outputPath}`);
+
+  try {
+    // Ensure the source directory exists
+    await fs.access(sourcePath);
+    console.log(`Source directory ${sourcePath} found.`);
+  } catch (error) {
+    console.error(`Error: Source directory ${sourcePath} not found or not accessible.`);
+    console.error('Please ensure you have prepared the Ubuntu filesystem at this location.');
+    console.error('Refer to step 3 of the plan for guidance on creating this directory.');
+    process.exit(1);
+  }
+
+  try {
+    // Ensure the output directory (public/) exists
+    const outputDir = path.dirname(outputPath);
+    await fs.mkdir(outputDir, { recursive: true });
+    console.log(`Ensured output directory ${outputDir} exists.`);
+
+    const binarySnapshot = await snapshot(sourcePath);
+    console.log('Snapshot generation successful.');
+
+    await fs.writeFile(outputPath, binarySnapshot);
+    console.log(`Snapshot successfully written to ${outputPath}`);
+    console.log('You can now proceed with modifying terminal-app.tsx.');
+
+  } catch (error) {
+    console.error('Error during snapshot generation or writing:', error);
+    process.exit(1);
+  }
+}
+
+generateSnapshot();


### PR DESCRIPTION
Adds @webcontainer/snapshot as a development dependency. Introduces a script, scripts/generate-ubuntu-snapshot.js, which uses @webcontainer/snapshot to convert a source directory (expected at assets/ubuntu-fs) into a binary snapshot file (output to public/ubuntu.bin).

Adds a 'build:ubuntu-snapshot' command to package.json to execute this script.

This prepares the groundwork for integrating an Ubuntu environment into the web terminal. The actual Ubuntu filesystem needs to be prepared separately and then processed by this script.